### PR TITLE
Add support for dynamic [angular driven] ids on the chart div

### DIFF
--- a/src/angular_c3_simple.js
+++ b/src/angular_c3_simple.js
@@ -24,10 +24,13 @@
           },
           template: '<div></div>',
           replace: true,
+          link: function(scope, elem, attr) {
+            scope.$evalAsync(function() {
+              // binding chart to element with provided ID
+              scope.config.bindto = '#' + elem[0].id;
+            })
+          },
           controller: function($scope, $element) {
-
-            // binding chart to element with provided ID
-            $scope.config.bindto = '#' + $element[0].id;
 
             //Generating the chart on every data change
             $scope.$watch('config.data.columns', function(newSeries, oldSeries) {

--- a/src/angular_c3_simple.js
+++ b/src/angular_c3_simple.js
@@ -24,11 +24,13 @@
           },
           template: '<div></div>',
           replace: true,
-          link: function(scope, elem, attr) {
-            scope.$evalAsync(function() {
+          link: function($scope, $element, $attr) {
+
+            // Wait until id is set before binding chart to this id
+            $scope.$watch($attr.id, function() {
               // binding chart to element with provided ID
-              scope.config.bindto = '#' + elem[0].id;
-            })
+              $scope.config.bindto = '#' + $attr.id;
+            });
           },
           controller: function($scope, $element) {
 


### PR DESCRIPTION
I wanted to dynamically set the chart's id, e.g.:
<c3-simple id="{{ dynamicId }}" config="chart"></c3-simple>

Unless I'm missing something, this wasn't supported.  So this tweak simply sets the bindto once id is ready.  If you'd like, feel free to pull this in!

[Thanks for putting this together in the first place - it's a nice directive!]
