### PR TITLE
Fix "main" path at bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "angular-c3-simple",
   "description": "Simple C3.js wrapper for AngularJS.",
-  "main": "dist/angular_c3_simple.js",
+  "main": "dist/angular_c3_simple.min.js",
   "keywords": ["angularjs", "c3", "chart"],
   "homepage": "https://github.com/wasilak/angular-c3-simple",
   "repository": {


### PR DESCRIPTION
Fixing the path to the main file of the library in the bower.json file. Previously it was set as "dist/angular_c3_simple.js", however, the dist directory does not contain such file, but contains dist/angular_c3_simple.min.js instead.
